### PR TITLE
ANS-006-167 Utilisation du code EXPORT_DUI pour l'élément DocumentReference.type

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -5,3 +5,4 @@ Alias: $JDV-J04-XdsPracticeSettingCode-CISIS = https://mos.esante.gouv.fr/NOS/JD
 Alias: $JDV-J10-XdsFormatCode-CISIS = https://mos.esante.gouv.fr/NOS/JDV_J10-XdsFormatCode-CISIS/FHIR/JDV-J10-XdsFormatCode-CISIS
 Alias: $TRE-A04-Loinc = https://mos.esante.gouv.fr/NOS/TRE_A04-Loinc/FHIR/TRE-A04-Loinc
 Alias: $TRE-A03-ClasseDocument = https://mos.esante.gouv.fr/NOS/TRE_A03-ClasseDocument/FHIR/TRE-A03-ClasseDocument
+Alias: $TRE-A05-TypeDocComplementaire = https://mos.esante.gouv.fr/NOS/TRE_A05-TypeDocComplementaire/FHIR/TRE-A05-TypeDocComplementaire

--- a/input/fsh/instances/TDDUIBundleExample.fsh
+++ b/input/fsh/instances/TDDUIBundleExample.fsh
@@ -20,7 +20,7 @@ Usage: #inline
 * meta.profile = "https://interop.esante.gouv.fr/ig/fhir/tddui/StructureDefinition/tddui-documentreference"
 * masterIdentifier.value = "2569874526325"
 * status = #current
-* type = $TRE-A04-Loinc#28653-4 "Document du secteur social / médico-social"
+* type = $TRE-A05-TypeDocComplementaire#EXPORT_DUI
 * category = $TRE-A03-ClasseDocument#95 "Document de gestion"
 * content.attachment.contentType = #text/plain
 * content.attachment.language = #fr
@@ -36,7 +36,7 @@ Usage: #inline
 * meta.profile = "https://interop.esante.gouv.fr/ig/fhir/tddui/StructureDefinition/tddui-documentreference"
 * masterIdentifier.value = "2569874526326"
 * status = #current
-* type = $TRE-A04-Loinc#28653-4 "Document du secteur social / médico-social"
+* type = $TRE-A05-TypeDocComplementaire#EXPORT_DUI
 * category = $TRE-A03-ClasseDocument#95 "Document de gestion"
 * content.attachment.contentType = #text/plain
 * content.attachment.language = #fr

--- a/input/fsh/instances/TDDUIDocumentReferenceExample.fsh
+++ b/input/fsh/instances/TDDUIDocumentReferenceExample.fsh
@@ -8,7 +8,7 @@ Usage: #example
 * meta.profile = "https://interop.esante.gouv.fr/ig/fhir/tddui/StructureDefinition/tddui-documentreference"
 * masterIdentifier.value = "2569874526325"
 * status = #current
-* type = $TRE-A04-Loinc#28653-4
+* type = $TRE-A05-TypeDocComplementaire#EXPORT_DUI
 * category = $TRE-A03-ClasseDocument#95
 * content.attachment.contentType = #text/plain
 * content.attachment.language = #fr


### PR DESCRIPTION
## Description des changements

* Modification des exemples pour utiliser un code de la TRE A05 pour l'attribut type
* Ajout d'un alias pour la TRE A05


## Preview

https://ansforge.github.io/IG-contenu-cda-medicosocial-transfert-donnees-dui/21-exemple-fhir---utilisation-du-code-export_dui-pour-lélément-documentreferencetype/ig
